### PR TITLE
feat: add global exception handler to handle all exceptions with standardized response

### DIFF
--- a/backend/src/main/java/com/backend/dto/response/ErrorResponse.java
+++ b/backend/src/main/java/com/backend/dto/response/ErrorResponse.java
@@ -1,0 +1,22 @@
+package com.backend.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+import java.util.Map;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ErrorResponse {
+    @Builder.Default
+    private String timestamp = Instant.now().toString();
+    private int status;
+    private String errorCode;
+    private String message;
+    private String traceId;
+    private Map<String, Object> details;
+    private String path;
+}

--- a/backend/src/main/java/com/backend/enums/ErrorCode.java
+++ b/backend/src/main/java/com/backend/enums/ErrorCode.java
@@ -1,0 +1,38 @@
+package com.backend.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    // AUTH
+    UNAUTHORIZED("AUTH_001", "Chưa đăng nhập hoặc token không hợp lệ", HttpStatus.UNAUTHORIZED),
+    FORBIDDEN("AUTH_002", "Không có quyền truy cập tài nguyên này", HttpStatus.FORBIDDEN),
+    ACCESS_DENIED("AUTH_003", "Không có quyền thao tác trên tài nguyên này", HttpStatus.FORBIDDEN),
+
+    // DATABASE
+    DUPLICATE_KEY("DB_001", "Dữ liệu bị trùng (vi phạm unique)", HttpStatus.CONFLICT),
+    DATA_INTEGRITY_VIOLATION("DB_002", "Vi phạm ràng buộc dữ liệu", HttpStatus.BAD_REQUEST),
+
+    // BUSINESS
+    USER_NOT_FOUND("BUS_001", "Không tìm thấy người dùng", HttpStatus.BAD_REQUEST),
+
+    // VALIDATION
+    VALIDATION_FAILED("VALID_001", "Dữ liệu không hợp lệ", HttpStatus.BAD_REQUEST),
+
+
+    // SYSTEM
+    SYSTEM_ERROR("SYS_001", "Lỗi hệ thống nội bộ", HttpStatus.INTERNAL_SERVER_ERROR),
+    EXTERNAL_SERVICE_ERROR("SYS_002", "Lỗi dịch vụ bên ngoài", HttpStatus.BAD_GATEWAY),
+
+    // HTTP
+    HTTP_NOT_FOUND("HTTP_404", "API không tồn tại", HttpStatus.NOT_FOUND),
+    HTTP_METHOD_NOT_ALLOWED("HTTP_405", "Phương thức không được hỗ trợ", HttpStatus.METHOD_NOT_ALLOWED),
+    HTTP_BAD_REQUEST("HTTP_400", "Yêu cầu không hợp lệ", HttpStatus.BAD_REQUEST);
+
+    private final String code;
+    private final String defaultMessage;
+    private final HttpStatus httpStatus;
+}

--- a/backend/src/main/java/com/backend/exception/AppException.java
+++ b/backend/src/main/java/com/backend/exception/AppException.java
@@ -1,0 +1,34 @@
+package com.backend.exception;
+
+import com.backend.enums.ErrorCode;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class AppException extends RuntimeException {
+    private final ErrorCode errorCode;
+    private final Map<String, Object> details;
+
+    public AppException(ErrorCode errorCode) {
+        super(errorCode.getDefaultMessage());
+        this.errorCode = errorCode;
+        this.details = null;
+    }
+
+    public AppException(ErrorCode errorCode, String overrideMessage) {
+        super(overrideMessage != null ? overrideMessage : errorCode.getDefaultMessage());
+        this.errorCode = errorCode;
+        this.details = null;
+    }
+
+    public AppException(ErrorCode errorCode, String overrideMessage, Map<String, Object> details) {
+        super(overrideMessage != null ? overrideMessage : errorCode.getDefaultMessage());
+        this.errorCode = errorCode;
+        this.details = details;
+    }
+
+    public int getHttpStatus() {
+        return errorCode.getHttpStatus().value();
+    }
+}

--- a/backend/src/main/java/com/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/backend/exception/GlobalExceptionHandler.java
@@ -1,0 +1,131 @@
+package com.backend.exception;
+
+import com.backend.dto.response.ErrorResponse;
+import com.backend.enums.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@ControllerAdvice
+public class GlobalExceptionHandler{
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @ExceptionHandler(AppException.class)
+    public ResponseEntity<ErrorResponse> handleAppException(AppException ex, HttpServletRequest request) {
+        ErrorResponse response = ErrorResponse.builder()
+                .timestamp(Instant.now().toString())
+                .status(ex.getHttpStatus())
+                .errorCode(ex.getErrorCode().getCode())
+                .message(ex.getMessage())
+                .traceId(MDC.get("traceId")) // nếu có tích hợp logging
+                .details(ex.getDetails())
+                .path(request.getRequestURI())
+                .build();
+        return ResponseEntity.status(ex.getHttpStatus()).body(response);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGeneralException(Exception ex, HttpServletRequest request) {
+
+        log.error("Unexpected error", ex);
+
+        String message = ex.getMessage();
+        if (message == null && ex.getCause() != null) {
+            message = ex.getCause().getMessage();
+        }
+
+        ErrorResponse response = ErrorResponse.builder()
+                .timestamp(Instant.now().toString())
+                .status(ErrorCode.SYSTEM_ERROR.getHttpStatus().value())
+                .errorCode(ErrorCode.SYSTEM_ERROR.getCode())
+                .message(ex.getMessage())
+                .traceId(MDC.get("traceId"))
+                .path(request.getRequestURI())
+                .build();
+        return ResponseEntity.status(ErrorCode.SYSTEM_ERROR.getHttpStatus()).body(response);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException ex,
+                                                          HttpServletRequest request) {
+        Map<String, Object> details = ex.getBindingResult().getFieldErrors().stream()
+                .collect(Collectors.toMap(FieldError::getField, DefaultMessageSourceResolvable::getDefaultMessage));
+
+        ErrorResponse response = ErrorResponse.builder()
+                .timestamp(Instant.now().toString())
+                .status(ErrorCode.VALIDATION_FAILED.getHttpStatus().value())
+                .errorCode(ErrorCode.VALIDATION_FAILED.getCode())
+                .message(ErrorCode.VALIDATION_FAILED.getDefaultMessage())
+                .details(details)
+                .traceId(MDC.get("traceId"))
+                .path(request.getRequestURI())
+                .build();
+
+        return ResponseEntity.status(ErrorCode.VALIDATION_FAILED.getHttpStatus()).body(response);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolation(ConstraintViolationException ex,
+                                                                   HttpServletRequest request) {
+        Map<String, Object> details = ex.getConstraintViolations().stream()
+                .collect(Collectors.toMap(v -> v.getPropertyPath().toString(), ConstraintViolation::getMessage));
+
+        ErrorResponse response = ErrorResponse.builder()
+                .timestamp(Instant.now().toString())
+                .status(ErrorCode.VALIDATION_FAILED.getHttpStatus().value())
+                .errorCode(ErrorCode.VALIDATION_FAILED.getCode())
+                .message(ErrorCode.VALIDATION_FAILED.getDefaultMessage())
+                .details(details)
+                .traceId(MDC.get("traceId"))
+                .path(request.getRequestURI())
+                .build();
+
+        return ResponseEntity.status(ErrorCode.VALIDATION_FAILED.getHttpStatus()).body(response);
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ErrorResponse> handleDataIntegrity(DataIntegrityViolationException ex,
+                                                             HttpServletRequest request) {
+        ErrorResponse response = ErrorResponse.builder()
+                .timestamp(Instant.now().toString())
+                .status(ErrorCode.DATA_INTEGRITY_VIOLATION.getHttpStatus().value())
+                .errorCode(ErrorCode.DATA_INTEGRITY_VIOLATION.getCode())
+                .message(ErrorCode.DATA_INTEGRITY_VIOLATION.getDefaultMessage())
+                .traceId(MDC.get("traceId"))
+                .path(request.getRequestURI())
+                .build();
+
+        return ResponseEntity.status(ErrorCode.DATA_INTEGRITY_VIOLATION.getHttpStatus()).body(response);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDenied(AccessDeniedException ex, HttpServletRequest request) {
+        ErrorResponse response = ErrorResponse.builder()
+                .timestamp(Instant.now().toString())
+                .status(ErrorCode.FORBIDDEN.getHttpStatus().value())
+                .errorCode(ErrorCode.FORBIDDEN.getCode())
+                .message(ErrorCode.FORBIDDEN.getDefaultMessage())
+                .traceId(MDC.get("traceId"))
+                .path(request.getRequestURI())
+                .build();
+
+        return ResponseEntity.status(ErrorCode.FORBIDDEN.getHttpStatus()).body(response);
+    }
+
+
+}


### PR DESCRIPTION
What:
- Added GlobalExceptionHandler using @ControllerAdvice
- Handles common exceptions: ResourceNotFoundException, ValidationException, AccessDeniedException
- Returns standardized error response with HTTP status and message

Why:
- Ensure all REST API errors return consistent response format
- Simplify client error handling and debugging

How:
- Created GlobalExceptionHandler class with @ExceptionHandler methods
- Mapped exceptions to appropriate HTTP status codes
- Included logging for unexpected exceptions

Testing:
- Verified endpoints with invalid input and missing resources
- Checked HTTP status codes and error messages in responses
