### PR TITLE
feat(config): add Swagger/OpenAPI configuration for backend

### DIFF
--- a/backend/src/main/java/com/backend/config/OpenAPIConfig.java
+++ b/backend/src/main/java/com/backend/config/OpenAPIConfig.java
@@ -1,0 +1,27 @@
+package com.backend.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class OpenAPIConfig {
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return  new OpenAPI()
+                .info(new Info().title("StudyMate API-service").version("1.0"))
+                .components(new Components()
+                        .addSecuritySchemes("Bearer",
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")))
+                .security(List.of(new SecurityRequirement().addList("Bearer")));
+    }
+}


### PR DESCRIPTION
This module adds Swagger UI and OpenAPI 3 documentation to the backend, enabling developers to:

Explore and test all RESTful endpoints directly from a web interface.
View request and response schemas for each API endpoint.
Test public APIs (e.g., authentication, registration) without using a separate client.
Easily share API documentation with frontend or third-party developers.

Features:
Swagger UI accessible at /swagger-ui.html or /swagger-ui/index.html.
OpenAPI JSON/YAML documentation available at /v3/api-docs.
Supports request validation annotations for better API schema generation.
Configurable to include/exclude endpoints per environment or profile.

Usage:
Run the backend application.
Open your browser and go to /swagger-ui.html.
Explore and test available APIs.